### PR TITLE
Add Renode package (linux, osx, windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,20 @@ jobs:
       dist: xenial
       env:
       - PACKAGE=sigrok-cli
+    - stage: "Miscellaneous"
+      os: linux
+      dist: xenial
+      env:
+      - PACKAGE=renode
+    - stage: "Miscellaneous"
+      os: osx
+      osx_image: xcode8.3
+      env:
+      - PACKAGE=renode
+    - stage: "Miscellaneous"
+      os: windows
+      env:
+      - PACKAGE=renode
   fast_finish: true
 
 before_install:

--- a/renode/build_without_gui.patch
+++ b/renode/build_without_gui.patch
@@ -1,0 +1,49 @@
+--- build.sh
++++ build.sh
+@@ -5,45 +5,9 @@
+ if [[ "$(uname)" == 'Linux' ]]; then
+     install -D /usr/bin/realpath $BUILD_PREFIX/bin/realpath
+     install -D /bin/sed $BUILD_PREFIX/bin/sed
+-
+-    # Install gtk-sharp2
+-    install -D /usr/lib/cli/gtk-sharp-2.0/gtk-sharp.dll* $BUILD_PREFIX/lib/mono/4.5-api/
+-    install -D /usr/lib/cli/glib-sharp-2.0/glib-sharp.dll* $BUILD_PREFIX/lib/mono/4.5-api/
+-    install -D /usr/lib/cli/atk-sharp-2.0/atk-sharp.dll* $BUILD_PREFIX/lib/mono/4.5-api/
+-    install -D /usr/lib/cli/gdk-sharp-2.0/gdk-sharp.dll* $BUILD_PREFIX/lib/mono/4.5-api/
+-    install -D /usr/lib/cli/pango-sharp-2.0/pango-sharp.dll* $BUILD_PREFIX/lib/mono/4.5-api/
+-
+-
+-    mkdir -p $PREFIX/opt/renode/bin
+-    cp /usr/lib/cli/gtk-sharp-2.0/gtk-sharp.dll* $PREFIX/opt/renode/bin/
+-    cp /usr/lib/cli/glib-sharp-2.0/glib-sharp.dll* $PREFIX/opt/renode/bin/
+-    cp /usr/lib/cli/atk-sharp-2.0/atk-sharp.dll* $PREFIX/opt/renode/bin/
+-    cp /usr/lib/cli/gdk-sharp-2.0/gdk-sharp.dll* $PREFIX/opt/renode/bin/
+-    cp /usr/lib/cli/pango-sharp-2.0/pango-sharp.dll* $PREFIX/opt/renode/bin/
+-
+-    mkdir -p $PREFIX/lib/
+-    install -D /usr/lib/cli/gtk-sharp-2.0/libgtksharpglue-2.so $PREFIX/lib/libgtksharpglue-2.so
+-    install -D /usr/lib/cli/gdk-sharp-2.0/libgdksharpglue-2.so $PREFIX/lib/libgdksharpglue-2.so
+-    install -D /usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so $PREFIX/lib/libglibsharpglue-2.so
+-    install -D /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/libatk-bridge.so $PREFIX/lib/libatk-bridge.so
+-
+-    sed -i 's/\/usr\/lib\/cli\/.*-sharp-2.0\///g' $PREFIX/opt/renode/bin/*.dll.config
+-else
+-    cp /Library/Frameworks/Mono.framework/Libraries/libatksharpglue-2* $PREFIX/lib/
+-    cp /Library/Frameworks/Mono.framework/Libraries/libgtksharpglue-2* $PREFIX/lib/
+-    cp /Library/Frameworks/Mono.framework/Libraries/libgdksharpglue-2* $PREFIX/lib/
+-    cp /Library/Frameworks/Mono.framework/Libraries/libglibsharpglue-2* $PREFIX/lib/
+-
+-    mkdir -p $BUILD_PREFIX/lib/mono/4.5-api/
+-    find /Library/Frameworks/Mono.framework/Versions/5*/lib/mono/* -name 'gtk-sharp.dll*' -exec cp '{}' $BUILD_PREFIX/lib/mono/4.5-api/ ';'
+-    find /Library/Frameworks/Mono.framework/Versions/5*/lib/mono/* -name 'gdk-sharp.dll*' -exec cp '{}' $BUILD_PREFIX/lib/mono/4.5-api/ ';'
+-    find /Library/Frameworks/Mono.framework/Versions/5*/lib/mono/* -name 'atk-sharp.dll*' -exec cp '{}' $BUILD_PREFIX/lib/mono/4.5-api/ ';'
+-    find /Library/Frameworks/Mono.framework/Versions/5*/lib/mono/* -name 'glib-sharp.dll*' -exec cp '{}' $BUILD_PREFIX/lib/mono/4.5-api/ ';'
+-    find /Library/Frameworks/Mono.framework/Versions/5*/lib/mono/* -name 'pango-sharp.dll*' -exec cp '{}' $BUILD_PREFIX/lib/mono/4.5-api/ ';'
+-    cp /usr/lib/libc.dylib $PREFIX/lib/
+ fi
+ 
+-./build.sh
++./build.sh --no-gui
+ 
+ mkdir -p $PREFIX/opt/renode/bin
+ mkdir -p $PREFIX/opt/renode/scripts

--- a/renode/build_without_gui_win.patch
+++ b/renode/build_without_gui_win.patch
@@ -1,0 +1,12 @@
+--- bld.bat
++++ bld.bat
+@@ -4,7 +4,7 @@ set PATH=C:\cygwin64\bin\;%PATH%
+ set PLATFORM=Any CPU
+ for /r %%i in (*.sh) do  CALL :convert_to_unix_newline %%i
+ 
+-call bash build.sh
++call bash build.sh --no-gui
+ 
+ REM Need to use call for all functions outside of script, otherwise label handling go crazy
+ call mkdir %LIBRARY_PREFIX%\renode\exec
+

--- a/renode/condarc
+++ b/renode/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/renode/meta.yaml
+++ b/renode/meta.yaml
@@ -1,0 +1,5 @@
+# This file will be replaced by the renode's meta.yaml after running "prescript..sh"
+
+package:
+  name: meta_stub
+  version: "0.0"

--- a/renode/meta_add_travis_patches.patch
+++ b/renode/meta_add_travis_patches.patch
@@ -1,0 +1,12 @@
+--- meta.yaml
++++ meta.yaml
+@@ -7,6 +7,9 @@
+     git_rev: master
+     patches:
+         - lower_mono_version.patch [not win]
++        # Travis-specific patches
++        - osx_mono_name.patch      [osx]
++        - win_msbuild_params.patch [win]
+ 
+ build:
+     missing_dso_whitelist:

--- a/renode/meta_headless.patch
+++ b/renode/meta_headless.patch
@@ -1,14 +1,5 @@
 --- meta.yaml
 +++ meta.yaml
-@@ -1,5 +1,7 @@
- package:
--    name: renode
-+    name: renode          [win]
-+    # GtkSharp libraries can't be provided through Conda
-+    name: renode-headless [not win]
-     version: {{GIT_DESCRIBE_TAG}}
- 
- source:
 @@ -27,19 +29,13 @@
          - autoconf       [not win]
          - libtool        [not win]

--- a/renode/meta_headless_linux_and_osx.patch
+++ b/renode/meta_headless_linux_and_osx.patch
@@ -1,0 +1,31 @@
+--- meta.yaml
++++ meta.yaml
+@@ -1,5 +1,7 @@
+ package:
+-    name: renode
++    name: renode          [win]
++    # GtkSharp libraries can't be provided through Conda
++    name: renode-headless [not win]
+     version: {{GIT_DESCRIBE_TAG}}
+ 
+ source:
+@@ -27,19 +29,13 @@
+         - autoconf       [not win]
+         - libtool        [not win]
+         - mono           [not win]
+-        - gtk2           [not win]
+         - vc >=10        [win]
+     run:
+         - python 2.7.*   [not win]
+         - python         [win]
+         - glib           [not win]
+         - mono           [not win]
+-        - gtk2           [not win]
+         - pcre           [not win]
+-        - cairo          [not win]
+-        - pango          [not win]
+-        - atk            [not win]
+-        - fontconfig     [not win]
+         - robotframework
+         - netifaces
+         - requests

--- a/renode/osx_mono_name.patch
+++ b/renode/osx_mono_name.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/common.sh b/tools/common.sh
+index c9afba0..d16d118 100755
+--- a/tools/common.sh
++++ b/tools/common.sh
+@@ -14,7 +14,7 @@ then
+     ON_OSX=true
+     ON_LINUX=false
+     CS_COMPILER=xbuild
+-    LAUNCHER="mono64"
++    LAUNCHER="mono"
+ else
+     DETECTED_OS="windows"
+     ON_WINDOWS=true

--- a/renode/prescript..sh
+++ b/renode/prescript..sh
@@ -23,11 +23,12 @@ function patch-func {
 patch-func meta.yaml meta_add_travis_patches.patch
 
 # Build headless Renode on Linux and macOS (there's no Conda package with GtkSharp)
-patch-func meta.yaml meta_headless_linux_and_osx.patch
+patch-func meta.yaml meta_headless.patch
 patch-func build.sh build_without_gui.patch
+patch-func bld.bat build_without_gui_win.patch
 
 # Clean the recipe
 rm meta_add_travis_patches.patch
-rm meta_headless_linux_and_osx.patch
+rm meta_headless.patch
 rm build_without_gui.patch
 rm prescript..sh

--- a/renode/prescript..sh
+++ b/renode/prescript..sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -x
+
+cd "$PACKAGE"
+
+# Copy the recipe from the Renode's master
+git clone --depth 1 https://github.com/renode/renode.git
+mv renode/tools/packaging/conda/* .
+rm -rf renode
+rm README.rst
+
+# Patch the recipe
+function patch-func {
+    if ! patch --no-backup-if-mismatch "$1" "$2"; then
+        # Print the rejected part of the diff
+        cat "$1.rej"
+        exit -1
+    fi
+}
+
+# Add Travis-specific patches for Renode repository files
+patch-func meta.yaml meta_add_travis_patches.patch
+
+# Build headless Renode on Linux and macOS (there's no Conda package with GtkSharp)
+patch-func meta.yaml meta_headless_linux_and_osx.patch
+patch-func build.sh build_without_gui.patch
+
+# Clean the recipe
+rm meta_add_travis_patches.patch
+rm meta_headless_linux_and_osx.patch
+rm build_without_gui.patch
+rm prescript..sh

--- a/renode/win_msbuild_params.patch
+++ b/renode/win_msbuild_params.patch
@@ -1,0 +1,40 @@
+diff --git a/build.sh b/build.sh
+index 055969d..b4b310f 100755
+--- a/build.sh
++++ b/build.sh
+@@ -105,7 +105,7 @@ fi
+ if $HEADLESS
+ then
+     BUILD_TARGET=Headless
+-    PARAMS+=(/p:GUI_DISABLED=true)
++    PARAMS+=(-p:GUI_DISABLED=true)
+ elif $ON_WINDOWS
+ then
+     BUILD_TARGET=Windows
+@@ -173,7 +173,7 @@ fi
+ cp "$PROP_FILE" "$OUTPUT_DIRECTORY/properties.csproj"
+ 
+ # Build CCTask in Release configuration
+-$CS_COMPILER /p:Configuration=Release "`get_path \"$ROOT_PATH/lib/cctask/CCTask.sln\"`" > /dev/null
++$CS_COMPILER -p:Configuration=Release "`get_path \"$ROOT_PATH/lib/cctask/CCTask.sln\"`" > /dev/null
+ 
+ # clean instead of building
+ if $CLEAN
+@@ -183,7 +183,7 @@ then
+     do
+         for build_target in Windows Mono Headless
+         do
+-            $CS_COMPILER "${PARAMS[@]}" /p:Configuration=${conf}${build_target} "$TARGET"
++            $CS_COMPILER "${PARAMS[@]}" -p:Configuration=${conf}${build_target} "$TARGET"
+         done
+         rm -fr $OUTPUT_DIRECTORY/bin/$conf
+     done
+@@ -195,7 +195,7 @@ pushd "$ROOT_PATH/tools/building" > /dev/null
+ ./check_weak_implementations.sh
+ popd > /dev/null
+ 
+-PARAMS+=(/p:Configuration=${CONFIGURATION}${BUILD_TARGET} /p:GenerateFullPaths=true)
++PARAMS+=(-p:Configuration=${CONFIGURATION}${BUILD_TARGET} -p:GenerateFullPaths=true)
+ 
+ # build
+ $CS_COMPILER "${PARAMS[@]}" "$TARGET"


### PR DESCRIPTION
The package uses a script to download the current Renode recipe before
executing 'conda build' and patch it for building with Travis (there are
mostly minor differences e.g. because of the 'msbuild' version).

The most important difference is, the Renode on Linux and macOS can't
be built with GUI support. That's because GtkSharp libraries can't be
provided through Conda. Such headless version of Renode can still be
used using telnet as a terminal, however.

Prescript doesn't influence the build itself. All files used to create
the recipe from the one found in Renode repository (including the
prescript itself) are actually cleaned before executing 'conda build',
so they won't be packaged either.