### PR TITLE
Fix macOS compiling problems and update Renode's `osx_mono_name.patch`

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,3 @@
+CONDA_BUILD_SYSROOT:
+  - /Users/travis/sdk/MacOSX10.9.sdk        # [osx]
+

--- a/renode/osx_mono_name.patch
+++ b/renode/osx_mono_name.patch
@@ -8,6 +8,6 @@ index d016551..794a02b 100755
      CS_COMPILER=xbuild
 -    LAUNCHER="mono64"
 +    LAUNCHER="mono"
-     PYTHON_RUNNER="python2"
+     PYTHON_RUNNER="python3"
  else
      DETECTED_OS="windows"

--- a/sigrok-cli/meta.yaml
+++ b/sigrok-cli/meta.yaml
@@ -3,6 +3,9 @@ package:
   version: {{ GIT_FULL_HASH }}
 
 source:
+  - git_url: https://github.com/sigrokproject/sigrok-cli
+    git_rev: master
+    folder: sigrok-cli
   - git_url: https://github.com/sigrokproject/libserialport
     git_rev: master
     folder: libserialport
@@ -12,9 +15,6 @@ source:
   - git_url: https://github.com/sigrokproject/libsigrokdecode
     git_rev: master
     folder: libsigrokdecode
-  - git_url: https://github.com/sigrokproject/sigrok-cli
-    git_rev: master
-    folder: sigrok-cli
 
 build:
   number: {{ '1%04i00%s'|format(GIT_DESCRIBE_NUMBER|int, os.environ.get('DATESTR')) }}
@@ -27,6 +27,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - autoconf
+    - automake
+    - libtool
+    - make
     - pkg-config
     # C++ bindings
     - doxygen


### PR DESCRIPTION
Commits were combined into one PR because both are needed to have CI fully green.