### PR TITLE
Add surelog package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,10 @@ jobs:
       os: linux
       env:
       - PACKAGE=capnproto-java
+    - stage: "No dependencies"
+      os: linux
+      env:
+      - PACKAGE=surelog
 
   # Move packages from the current label to main
     - stage: "Main label upload"

--- a/surelog/build.sh
+++ b/surelog/build.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+  CPU_COUNT=2
+fi
+
+export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/"
+export CXXFLAGS="$CXXFLAGS -I$BUILD_PREFIX/include"
+export LDFLAGS="$CXXFLAGS -L$BUILD_PREFIX/lib -lrt -ltinfo"
+
+make -j$CPU_COUNT
+make -j$CPU_COUNT install

--- a/surelog/meta.yaml
+++ b/surelog/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: surelog
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/alainmarcel/Surelog
+  git_rev: master
+
+build:
+  number: {{ environ.get('DATE_NUM') }}
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - python {{ python }}
+    - cmake
+    - pkg-config
+    - libuuid
+    - flex
+    - swig
+
+  run:
+    - python {{ python }}
+
+about:
+  home: https://github.com/alainmarcel/Surelog
+  license: Apache
+  license_file: LICENSE
+  summary: 'Parser/Compiler for SystemVerilog'


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This package is required in [v2x](https://github.com/SymbiFlow/python-symbiflow-v2x) and there currently is an Anaconda/symbiflow version of it, but it contains conda-forge dependencies, which generate several conflicts when installing this package.