### PR TITLE
Fix recipes to only use Conda-based tools

### DIFF
--- a/capnproto-java/meta.yaml
+++ b/capnproto-java/meta.yaml
@@ -21,11 +21,10 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - capnproto
     - pkg-config
+    - make
   host:
     - capnproto
-    - pkg-config
   run:
     - capnproto
 

--- a/capnproto/meta.yaml
+++ b/capnproto/meta.yaml
@@ -22,9 +22,10 @@ build:
 
 requirements:
   build:
-    - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake
+    - make
 
 test:
   commands:

--- a/dtc/meta.yaml
+++ b/dtc/meta.yaml
@@ -22,8 +22,9 @@ requirements:
   build:
     - {{ compiler('c') }}  [linux]
     - clang                [osx]
-    - flex
     - bison
+    - flex
+    - make
     - pkg-config
   host:
     # Python bindings

--- a/wishbone-tool/build.sh
+++ b/wishbone-tool/build.sh
@@ -6,6 +6,7 @@ set -x
 
 
 cd wishbone-tool
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="$CC"
 cargo build --release
 
 install -d $PREFIX/bin

--- a/wishbone-tool/meta.yaml
+++ b/wishbone-tool/meta.yaml
@@ -19,6 +19,8 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - rust
 
 test:

--- a/zachjs-sv2v/meta.yaml
+++ b/zachjs-sv2v/meta.yaml
@@ -18,6 +18,13 @@ build:
 
 requirements:
   build:
+# There seems to be no way to make linker use `libgmp` from
+# the Conda's `gmp` package to build Cabal and zachjs-sv2v
+# dependencies (ld is called through stack -> cabal -> ghc).
+#
+# Therefore linker and `libgmp` have to be installed in the
+# OS (Conda `ld` doesn't work with OS-installed `libgmp`).
+    - make
     - stack<2.5.1
 
 test:


### PR DESCRIPTION
After trying to build the recipes on a clean Docker container created from the `ubuntu` image it turned out many of them are relying on the tools preinstalled in the Travis and GitHub Actions Operating Systems.

The changes make all of the recipes but `zachjs-sv2v` buildable without requiring any additional tools installed in the container.

The `zachjs-sv2v` is the only stubborn recipe. It has a haskell source and is built by the `Stack -> Cabal -> GHC (Glasgow Haskell Compiler) -> gcc` toolchain. The problem is that many dependencies built require `libgmp` but I have no idea how to supply it's Conda path to every command that links the binary. Also it turned out that `libgmp` installed in the OS couldn't be used by the Conda compiler.

Therefore the Ubuntu Docker container require installing `libgmp` and `build-essential` packages in the OS.