### PR TITLE
CI: Fix issues with logs, channel order and versioning; prevent conflicting doubled workflows in PRs

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,5 +1,12 @@
 name: build-packages
-on: [push, pull_request]
+on:
+  push:
+    # Prevents triggering multiple workflows in PRs. Workflows triggered from
+    # the same commit shouldn't run simultaneously because they're overwriting
+    # each other's packages on Anaconda.
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}


### PR DESCRIPTION
Now workflows won't be triggered automatically by pushing changes to the branch (apart from the master), but it will be possible to run those CIs manually.